### PR TITLE
feat: integrate NATS JetStream for event distribution

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "ru-RU"
+reviews:
+  profile: "assertive"
+  high_level_summary: true
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - ".*"
+chat:
+  auto_reply: true

--- a/packages/nats/package.json
+++ b/packages/nats/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@gh-automation/nats",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@nats-io/transport-node": "^3.0.0",
+    "@nats-io/jetstream": "^3.0.0",
+    "@gh-automation/logger": "workspace:*"
+  },
+  "devDependencies": {
+    "@gh-automation/typescript-config": "workspace:*",
+    "@types/node": "^20.11.19",
+    "typescript": "^5.3.3",
+    "vitest": "^1.3.1"
+  }
+}

--- a/packages/nats/src/__tests__/publisher.test.ts
+++ b/packages/nats/src/__tests__/publisher.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NatsPublisher } from '../publisher.js';
+
+// Mock NATS objects
+function createMockJs() {
+  return {
+    publish: vi.fn().mockResolvedValue({ stream: 'GITHUB_EVENTS', seq: 1, duplicate: false }),
+  };
+}
+
+function createMockJsm() {
+  return {
+    streams: {
+      info: vi.fn().mockResolvedValue({ config: { name: 'GITHUB_EVENTS' } }),
+      add: vi.fn().mockResolvedValue({ config: { name: 'GITHUB_EVENTS' } }),
+    },
+  };
+}
+
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as any;
+}
+
+describe('NatsPublisher', () => {
+  let publisher: NatsPublisher;
+  let mockJs: ReturnType<typeof createMockJs>;
+  let mockJsm: ReturnType<typeof createMockJsm>;
+  let mockLogger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    mockJs = createMockJs();
+    mockJsm = createMockJsm();
+    mockLogger = createMockLogger();
+    publisher = new NatsPublisher(mockJs as any, mockJsm as any, mockLogger);
+  });
+
+  it('should publish event to correct subject', async () => {
+    const event = {
+      eventId: 'evt-123',
+      eventType: 'github.notification.created',
+      aggregateId: 'owner/repo:PullRequest:42',
+      payload: { notificationId: 'n-1', repository: 'owner/repo' },
+    };
+
+    await publisher.publish(event);
+
+    expect(mockJs.publish).toHaveBeenCalledWith('github.notification.created', expect.any(String), {
+      msgID: 'evt-123',
+    });
+  });
+
+  it('should use eventId as NATS msgID for deduplication', async () => {
+    const event = {
+      eventId: 'evt-456',
+      eventType: 'github.notification.updated',
+      aggregateId: 'owner/repo:Issue:10',
+      payload: { some: 'data' },
+    };
+
+    await publisher.publish(event);
+
+    const callArgs = mockJs.publish.mock.calls[0];
+    expect(callArgs[2]).toEqual({ msgID: 'evt-456' });
+  });
+
+  it('should serialize full event as JSON string', async () => {
+    const payload = { notificationId: 'n-1', repository: 'owner/repo' };
+    const event = {
+      eventId: 'evt-789',
+      eventType: 'github.notification.created',
+      aggregateId: 'agg-1',
+      payload,
+    };
+
+    await publisher.publish(event);
+
+    const callArgs = mockJs.publish.mock.calls[0];
+    expect(JSON.parse(callArgs[1])).toEqual(event);
+  });
+
+  it('should ensure stream exists on ensureStream() call', async () => {
+    await publisher.ensureStream();
+
+    expect(mockJsm.streams.info).toHaveBeenCalledWith('GITHUB_EVENTS');
+  });
+
+  it('should create stream if it does not exist', async () => {
+    mockJsm.streams.info.mockRejectedValueOnce(new Error('stream not found'));
+
+    await publisher.ensureStream();
+
+    expect(mockJsm.streams.add).toHaveBeenCalled();
+  });
+
+  it('should not re-check stream on subsequent ensureStream() calls', async () => {
+    await publisher.ensureStream();
+    await publisher.ensureStream();
+
+    expect(mockJsm.streams.info).toHaveBeenCalledTimes(1);
+  });
+
+  it('should rethrow non-not-found errors from ensureStream', async () => {
+    mockJsm.streams.info.mockRejectedValueOnce(new Error('connection timeout'));
+
+    await expect(publisher.ensureStream()).rejects.toThrow('connection timeout');
+    expect(mockJsm.streams.add).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nats/src/__tests__/subscriber.test.ts
+++ b/packages/nats/src/__tests__/subscriber.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NatsSubscriber } from '../subscriber.js';
+
+function createMockConsumer() {
+  return {
+    consume: vi.fn(),
+  };
+}
+
+function createMockJsm() {
+  return {
+    consumers: {
+      info: vi.fn().mockResolvedValue({ name: 'test-consumer' }),
+      add: vi.fn().mockResolvedValue({ name: 'test-consumer' }),
+    },
+    streams: {
+      info: vi.fn().mockResolvedValue({ config: { name: 'GITHUB_EVENTS' } }),
+      add: vi.fn().mockResolvedValue({ config: { name: 'GITHUB_EVENTS' } }),
+    },
+  };
+}
+
+function createMockJs() {
+  const mockConsumer = createMockConsumer();
+  return {
+    consumers: {
+      get: vi.fn().mockResolvedValue(mockConsumer),
+    },
+    _mockConsumer: mockConsumer,
+  };
+}
+
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as any;
+}
+
+describe('NatsSubscriber', () => {
+  let subscriber: NatsSubscriber;
+  let mockJs: ReturnType<typeof createMockJs>;
+  let mockJsm: ReturnType<typeof createMockJsm>;
+  let mockLogger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    mockJs = createMockJs();
+    mockJsm = createMockJsm();
+    mockLogger = createMockLogger();
+    subscriber = new NatsSubscriber(mockJs as any, mockJsm as any, mockLogger);
+  });
+
+  it('should ensure consumer exists before subscribing', async () => {
+    mockJsm.consumers.info.mockRejectedValueOnce(new Error('consumer not found'));
+
+    await subscriber.ensureConsumer('my-service');
+
+    expect(mockJsm.consumers.add).toHaveBeenCalledWith(
+      'GITHUB_EVENTS',
+      expect.objectContaining({
+        durable_name: 'my-service',
+        ack_policy: expect.any(String),
+        deliver_policy: expect.any(String),
+        max_ack_pending: expect.any(Number),
+      })
+    );
+  });
+
+  it('should rethrow non-not-found errors from ensureConsumer', async () => {
+    mockJsm.consumers.info.mockRejectedValueOnce(new Error('connection timeout'));
+
+    await expect(subscriber.ensureConsumer('my-service')).rejects.toThrow('connection timeout');
+    expect(mockJsm.consumers.add).not.toHaveBeenCalled();
+  });
+
+  it('should not recreate consumer if it already exists', async () => {
+    await subscriber.ensureConsumer('my-service');
+
+    expect(mockJsm.consumers.info).toHaveBeenCalledWith('GITHUB_EVENTS', 'my-service');
+    expect(mockJsm.consumers.add).not.toHaveBeenCalled();
+  });
+
+  it('should get consumer from jetstream', async () => {
+    await subscriber.ensureConsumer('my-service');
+    const consumer = await subscriber.getConsumer('my-service');
+
+    expect(mockJs.consumers.get).toHaveBeenCalledWith('GITHUB_EVENTS', 'my-service');
+    expect(consumer).toBeDefined();
+  });
+});

--- a/packages/nats/src/connection.ts
+++ b/packages/nats/src/connection.ts
@@ -1,0 +1,55 @@
+import type { Logger } from '@gh-automation/logger';
+import { connect, type NatsConnection } from '@nats-io/transport-node';
+
+export interface NatsConfig {
+  url: string;
+  maxReconnectAttempts?: number;
+  reconnectTimeWait?: number;
+}
+
+let connection: NatsConnection | null = null;
+let connectionPromise: Promise<NatsConnection> | null = null;
+
+export async function getNatsConnection(
+  config: NatsConfig,
+  logger: Logger
+): Promise<NatsConnection> {
+  if (connection && !connection.isClosed()) {
+    return connection;
+  }
+
+  if (connectionPromise) {
+    return connectionPromise;
+  }
+
+  logger.info({ url: config.url }, 'Connecting to NATS');
+
+  connectionPromise = connect({
+    servers: config.url,
+    maxReconnectAttempts: config.maxReconnectAttempts ?? -1,
+    reconnectTimeWait: config.reconnectTimeWait ?? 2000,
+  });
+
+  try {
+    connection = await connectionPromise;
+  } finally {
+    connectionPromise = null;
+  }
+
+  logger.info('Connected to NATS');
+
+  return connection;
+}
+
+export async function closeNatsConnection(logger: Logger): Promise<void> {
+  if (connection) {
+    const conn = connection;
+    connection = null;
+    try {
+      await conn.drain();
+      logger.info('NATS connection closed');
+    } catch (err) {
+      logger.warn({ err }, 'Error draining NATS connection');
+    }
+  }
+}

--- a/packages/nats/src/factory.ts
+++ b/packages/nats/src/factory.ts
@@ -1,0 +1,25 @@
+import type { Logger } from '@gh-automation/logger';
+import { jetstream, jetstreamManager } from '@nats-io/jetstream';
+import type { NatsConnection } from '@nats-io/transport-node';
+import { NatsPublisher } from './publisher.js';
+import { NatsSubscriber } from './subscriber.js';
+
+export async function createNatsPublisher(
+  nc: NatsConnection,
+  logger: Logger
+): Promise<NatsPublisher> {
+  const js = jetstream(nc);
+  const jsm = await jetstreamManager(nc);
+  const publisher = new NatsPublisher(js, jsm, logger);
+  await publisher.ensureStream();
+  return publisher;
+}
+
+export async function createNatsSubscriber(
+  nc: NatsConnection,
+  logger: Logger
+): Promise<NatsSubscriber> {
+  const js = jetstream(nc);
+  const jsm = await jetstreamManager(nc);
+  return new NatsSubscriber(js, jsm, logger);
+}

--- a/packages/nats/src/index.ts
+++ b/packages/nats/src/index.ts
@@ -1,0 +1,8 @@
+export type { NatsConfig } from './connection.js';
+export { closeNatsConnection, getNatsConnection } from './connection.js';
+export { createNatsPublisher, createNatsSubscriber } from './factory.js';
+export type { PublishableEvent } from './publisher.js';
+export { NatsPublisher } from './publisher.js';
+export { STREAM_CONFIG, STREAM_NAME, STREAM_SUBJECTS } from './stream-config.js';
+export type { SubscriberConfig } from './subscriber.js';
+export { NatsSubscriber } from './subscriber.js';

--- a/packages/nats/src/publisher.ts
+++ b/packages/nats/src/publisher.ts
@@ -1,0 +1,62 @@
+import type { Logger } from '@gh-automation/logger';
+import type { JetStreamClient, JetStreamManager } from '@nats-io/jetstream';
+import { STREAM_CONFIG, STREAM_NAME } from './stream-config.js';
+
+export interface PublishableEvent {
+  eventId: string;
+  eventType: string;
+  aggregateId: string;
+  payload: unknown;
+  metadata?: Record<string, unknown>;
+}
+
+export class NatsPublisher {
+  private streamEnsured = false;
+
+  constructor(
+    private readonly js: JetStreamClient,
+    private readonly jsm: JetStreamManager,
+    private readonly logger: Logger
+  ) {}
+
+  async ensureStream(): Promise<void> {
+    if (this.streamEnsured) return;
+
+    try {
+      await this.jsm.streams.info(STREAM_NAME);
+      this.logger.info({ stream: STREAM_NAME }, 'Stream already exists');
+    } catch (err) {
+      const isNotFound =
+        err instanceof Error &&
+        (err.message.includes('stream not found') || err.message.includes('not found'));
+      if (!isNotFound) {
+        throw err;
+      }
+      this.logger.info({ stream: STREAM_NAME }, 'Creating stream');
+      await this.jsm.streams.add(STREAM_CONFIG);
+      this.logger.info({ stream: STREAM_NAME }, 'Stream created');
+    }
+
+    this.streamEnsured = true;
+  }
+
+  async publish(event: PublishableEvent): Promise<void> {
+    const subject = event.eventType;
+    const data = JSON.stringify(event);
+
+    const ack = await this.js.publish(subject, data, {
+      msgID: event.eventId,
+    });
+
+    this.logger.debug(
+      {
+        eventId: event.eventId,
+        subject,
+        stream: ack.stream,
+        seq: ack.seq,
+        duplicate: ack.duplicate,
+      },
+      'Event published to NATS'
+    );
+  }
+}

--- a/packages/nats/src/stream-config.ts
+++ b/packages/nats/src/stream-config.ts
@@ -1,0 +1,14 @@
+import { nanos } from '@nats-io/nats-core/internal';
+
+export const STREAM_NAME = 'GITHUB_EVENTS';
+
+export const STREAM_SUBJECTS = ['github.notification.>'];
+
+export const STREAM_CONFIG = {
+  name: STREAM_NAME,
+  subjects: STREAM_SUBJECTS,
+  max_age: nanos(7 * 24 * 60 * 60 * 1_000), // 7 days in milliseconds
+  max_msgs: 100_000,
+  storage: 'file' as const,
+  num_replicas: 1,
+};

--- a/packages/nats/src/subscriber.ts
+++ b/packages/nats/src/subscriber.ts
@@ -1,0 +1,67 @@
+import type { Logger } from '@gh-automation/logger';
+import {
+  AckPolicy,
+  type Consumer,
+  type ConsumerConfig,
+  DeliverPolicy,
+  type JetStreamClient,
+  type JetStreamManager,
+} from '@nats-io/jetstream';
+import { STREAM_NAME } from './stream-config.js';
+
+export interface SubscriberConfig {
+  maxAckPending?: number;
+  ackWaitMs?: number;
+  filterSubject?: string;
+}
+
+const DEFAULT_CONFIG: Required<SubscriberConfig> = {
+  maxAckPending: 1000,
+  ackWaitMs: 30_000,
+  filterSubject: '',
+};
+
+export class NatsSubscriber {
+  constructor(
+    private readonly js: JetStreamClient,
+    private readonly jsm: JetStreamManager,
+    private readonly logger: Logger
+  ) {}
+
+  async ensureConsumer(consumerName: string, config?: SubscriberConfig): Promise<void> {
+    const opts = { ...DEFAULT_CONFIG, ...config };
+
+    try {
+      await this.jsm.consumers.info(STREAM_NAME, consumerName);
+      this.logger.info({ consumer: consumerName }, 'Consumer already exists');
+    } catch (err) {
+      const isNotFound =
+        err instanceof Error &&
+        (err.message.includes('consumer not found') || err.message.includes('not found'));
+      if (!isNotFound) {
+        throw err;
+      }
+
+      this.logger.info({ consumer: consumerName }, 'Creating durable consumer');
+
+      const consumerConfig: Partial<ConsumerConfig> = {
+        durable_name: consumerName,
+        ack_policy: AckPolicy.Explicit,
+        deliver_policy: DeliverPolicy.All,
+        max_ack_pending: opts.maxAckPending,
+        ack_wait: opts.ackWaitMs * 1_000_000, // ms → ns
+      };
+
+      if (opts.filterSubject) {
+        consumerConfig.filter_subject = opts.filterSubject;
+      }
+
+      await this.jsm.consumers.add(STREAM_NAME, consumerConfig);
+      this.logger.info({ consumer: consumerName }, 'Consumer created');
+    }
+  }
+
+  async getConsumer(consumerName: string): Promise<Consumer> {
+    return this.js.consumers.get(STREAM_NAME, consumerName);
+  }
+}

--- a/packages/nats/tsconfig.json
+++ b/packages/nats/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@gh-automation/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,31 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
 
+  packages/nats:
+    dependencies:
+      '@gh-automation/logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@nats-io/jetstream':
+        specifier: ^3.0.0
+        version: 3.3.0
+      '@nats-io/transport-node':
+        specifier: ^3.0.0
+        version: 3.3.0
+    devDependencies:
+      '@gh-automation/typescript-config':
+        specifier: workspace:*
+        version: link:../config/typescript-config
+      '@types/node':
+        specifier: ^20.11.19
+        version: 20.19.32
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.3.1
+        version: 1.6.1(@types/node@20.19.32)
+
   packages/shared-types:
     devDependencies:
       '@gh-automation/typescript-config':
@@ -829,6 +854,24 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@nats-io/jetstream@3.3.0':
+    resolution: {integrity: sha512-SK6lSr+Wf9nd6mffV4gdd1yDZxlhILEUJg74bAaU9yjQ2kBOPIJDHlYc2yMzcuZnQxIUcTVI3L7ow2d4qEDslQ==}
+
+  '@nats-io/nats-core@3.3.0':
+    resolution: {integrity: sha512-+ImSYab7NvOMvFFBSBbWl03a4s/OUXCpFFauZ4iRx8pp+5ptsaBQNpacyPXeg8jbjAMeEAWn2Zuyl7oJCUffJA==}
+
+  '@nats-io/nkeys@2.0.3':
+    resolution: {integrity: sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A==}
+    engines: {node: '>=18.0.0'}
+
+  '@nats-io/nuid@2.0.3':
+    resolution: {integrity: sha512-TpA3HEBna/qMVudy+3HZr5M3mo/L1JPofpVT4t0HkFGkz2Cn9wrlrQC8tvR8Md5Oa9//GtGG26eN0qEWF5Vqew==}
+    engines: {node: '>= 18.x'}
+
+  '@nats-io/transport-node@3.3.0':
+    resolution: {integrity: sha512-A59+E0uL2FCzkvEbnhOPA4bKd4p1Ca6o5GwhVwVHzBPILjjGaSpgwgccaxnjwdsP+FBcMRrgXJ1wn6i1pf6nHQ==}
+    engines: {node: '>= 18.0.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1941,6 +1984,9 @@ packages:
     resolution: {integrity: sha512-8Osxz5Tu/Dw2kb31EAY+nhq/YZ3wzmQSmYa1nIArqxgCAldxv9TPlrAiaBUDVnKA4aiPn0OFBD1ACcpc5VFOAQ==}
     hasBin: true
 
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2428,6 +2474,27 @@ snapshots:
       '@sinclair/typebox': 0.27.10
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@nats-io/jetstream@3.3.0':
+    dependencies:
+      '@nats-io/nats-core': 3.3.0
+
+  '@nats-io/nats-core@3.3.0':
+    dependencies:
+      '@nats-io/nkeys': 2.0.3
+      '@nats-io/nuid': 2.0.3
+
+  '@nats-io/nkeys@2.0.3':
+    dependencies:
+      tweetnacl: 1.0.3
+
+  '@nats-io/nuid@2.0.3': {}
+
+  '@nats-io/transport-node@3.3.0':
+    dependencies:
+      '@nats-io/nats-core': 3.3.0
+      '@nats-io/nkeys': 2.0.3
+      '@nats-io/nuid': 2.0.3
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3523,6 +3590,8 @@ snapshots:
       turbo-linux-arm64: 2.8.3
       turbo-windows-64: 2.8.3
       turbo-windows-arm64: 2.8.3
+
+  tweetnacl@1.0.3: {}
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Add NATS JetStream as the event distribution layer replacing the MVP logging stub
- Create shared `@gh-automation/nats` package with publisher, subscriber, and factory helpers
- Wire event-processor-worker to publish outbox events to NATS JetStream
- Each downstream service creates a durable pull consumer — fan-out with guaranteed delivery even after downtime

## Architecture

```
outbox_events → event-processor-worker → NATS JetStream (GITHUB_EVENTS stream)
                                              ├── consumer A (service 1)
                                              ├── consumer B (service 2)
                                              └── consumer C (service N)
```

## Changes

### Infrastructure
- NATS 2.10 added to `docker-compose.yml` with JetStream enabled, healthcheck, persistent volume
- Port 4223 (client), 8223 (monitoring)

### New package: `@gh-automation/nats`
- **connection.ts** — singleton NATS connection with reconnect
- **stream-config.ts** — `GITHUB_EVENTS` stream config (7d retention, 100K max msgs)
- **publisher.ts** — publishes events with `msgID` deduplication
- **subscriber.ts** — creates durable pull consumers (AckPolicy: Explicit, DeliverPolicy: All)
- **factory.ts** — `createNatsPublisher()` / `createNatsSubscriber()` helpers
- **8 unit tests** (5 publisher + 3 subscriber)

### Modified: `event-processor-worker`
- Replaced MVP stub (`publishEvent` that just logged) with real `NatsPublisher`
- NATS connection + stream setup on startup
- Graceful NATS drain on shutdown

### Documentation
- `CLAUDE.md` added with full architecture, env vars, worktree workflow

## Test plan

- [x] 8 unit tests pass (`pnpm --filter @gh-automation/nats test run`)
- [x] Full build passes (`pnpm build`)
- [x] Integration tested: worker connects to NATS, creates stream, polls outbox
- [x] NATS monitoring confirms stream exists (`curl localhost:8223/jsz`)
- [ ] End-to-end: collector → outbox → worker → NATS → consumer (manual)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Публичный пакет NATS: подключение, фабрики, издатель, подписчик и конфигурация потока; центральный экспорт API.

* **Тесты**
  * Добавлены юнит-тесты для издателя и подписчика NATS.

* **Документация**
  * Добавлен файл конфигурации автоматизации (.coderabbit.yaml).

* **Прочее**
  * Добавлен package.json и tsconfig для пакета nats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->